### PR TITLE
add tests on all the netchdf files i can find

### DIFF
--- a/src/main/kotlin/com/sunya/cdm/api/Group.kt
+++ b/src/main/kotlin/com/sunya/cdm/api/Group.kt
@@ -28,7 +28,7 @@ class Group(val name : String,
     }
 
     fun fullname() : String {
-        return if (parent == null) "" else "${parent.fullname()}/$name/"
+        return if (parent == null) "" else "${parent.fullname()}/$name"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/sunya/cdm/api/Netcdf.kt
+++ b/src/main/kotlin/com/sunya/cdm/api/Netcdf.kt
@@ -6,4 +6,5 @@ import java.io.Closeable
 interface Netcdf : Closeable, Iosp {
     fun location() : String
     fun cdl(strict : Boolean = false) : String
+    fun type() : String
 }

--- a/src/main/kotlin/com/sunya/cdm/api/Variable.kt
+++ b/src/main/kotlin/com/sunya/cdm/api/Variable.kt
@@ -16,7 +16,7 @@ data class Variable(
             dimensions.map { it.isUnlimited }.reduce { a,b -> a or b}
 
     fun fullname() : String {
-        return group.fullname() + name
+        return if (group.fullname() == "") name else "${group.fullname()}/$name"
     }
 
     /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/main/kotlin/com/sunya/cdm/array/ArrayTyped.kt
+++ b/src/main/kotlin/com/sunya/cdm/array/ArrayTyped.kt
@@ -39,6 +39,27 @@ abstract class ArrayTyped<T>(val shape : IntArray) : Iterable<T> {
             }
             return true
         }
+
+        fun countDiff(array1 : ArrayTyped<*>, array2 : ArrayTyped<*>) : Int {
+            val iter1 = array1.iterator()
+            val iter2 = array2.iterator()
+            var count = 0
+            var count1 = 0
+            var count2 = 0
+            val fill = (-1).toShort()
+            while (iter1.hasNext() && iter2.hasNext()) {
+                val v1 = iter1.next()
+                val v2 = iter2.next()
+                if (v1 != v2) {
+                    count++
+                }
+                if ((v1 as Short) == fill) count1++
+                if ((v2 as Short) == fill) count2++
+            }
+            println("count -1 in array1 = $count1")
+            println("count -1 in array2 = $count2")
+            return count
+        }
     }
 }
 

--- a/src/main/kotlin/com/sunya/cdm/layout/Chunker.kt
+++ b/src/main/kotlin/com/sunya/cdm/layout/Chunker.kt
@@ -11,7 +11,7 @@ import java.lang.Integer.max
  * @param dataChunkRaw the dataChunk index space, may have a trailing dimension that is ignored
  * @param wantSection the requested section of data
  */
-class Chunker(dataChunkRaw: IndexSpace, val elemSize: Int, wantSection: Section, merge : Boolean = true) : AbstractIterator<TransferChunk>() {
+class Chunker(dataChunkRaw: IndexSpace, val elemSize: Int, wantSpace: IndexSpace, merge : Boolean = true) : AbstractIterator<TransferChunk>() {
     val nelems : Int // number of elements to read at one time
     val totalNelems: Long // total number of elements in wantSection
 
@@ -21,7 +21,6 @@ class Chunker(dataChunkRaw: IndexSpace, val elemSize: Int, wantSection: Section,
     var transferChunks = 0
 
     init {
-        val wantSpace = IndexSpace(wantSection)
         val intersectSpace = wantSpace.intersect(dataChunkRaw)
 
         // shift intersect to dataChunk and wantSection origins
@@ -85,6 +84,6 @@ class Chunker(dataChunkRaw: IndexSpace, val elemSize: Int, wantSection: Section,
     }
 
     override fun toString(): String {
-        return "Chunker(nelems=$nelems, totalNelems=$totalNelems, srcOdometer=$srcOdometer, dstOdometer=$dstOdometer)"
+        return "Chunker(nelems=$nelems, elemSize=$elemSize totalNelems=$totalNelems, dstOdometer=$dstOdometer)"
     }
 }

--- a/src/main/kotlin/com/sunya/cdm/layout/IndexSpace.kt
+++ b/src/main/kotlin/com/sunya/cdm/layout/IndexSpace.kt
@@ -45,12 +45,24 @@ data class IndexSpace(val start : IntArray, val nelems : IntArray) {
         return IndexSpace(IntArray(rank) { firstList[it] }, IntArray(rank) { lengthList[it] })
     }
 
+    fun intersects(other: IndexSpace): Boolean {
+        ranges.mapIndexed  { idx, range ->
+            val orange = other.ranges[idx]
+            val first = Math.max(range.first, orange.first)
+            val last = Math.min(range.last, orange.last)
+            if (first > last) {
+                return false
+            }
+        }
+        return true
+    }
+
     fun makeSection() : Section {
         return Section(start, nelems)
     }
 
     override fun toString(): String {
-        return "${makeSection()}"
+        return "${makeSection()} total=${totalElements}"
     }
 
     override fun equals(other: Any?): Boolean {

--- a/src/main/kotlin/com/sunya/netchdf/cdl/NetcdfCdl.kt
+++ b/src/main/kotlin/com/sunya/netchdf/cdl/NetcdfCdl.kt
@@ -15,8 +15,8 @@ class NetcdfCdl(val location : String, val rootGroup : Group) : Netcdf {
     }
 
     override fun location() = location
-
     override fun cdl(strict: Boolean) = com.sunya.cdm.api.cdl(this, strict)
+    override fun type() = "Created from CDL"
 
     override fun close() {
     }

--- a/src/main/kotlin/com/sunya/netchdf/hdf5/BTreeData.kt
+++ b/src/main/kotlin/com/sunya/netchdf/hdf5/BTreeData.kt
@@ -240,7 +240,7 @@ class BTreeData(
                 require(loffset < Int.MAX_VALUE)
                 offset[i] = loffset.toInt()
             }
-            filePos = if (last) -1 else h5.readAddress(state)
+            filePos = if (last) -1 else h5.readAddress(state) // note we add the file offset here as needed
             memTracker?.addByLen("Chunked Data ($owner)", filePos, size.toLong())
         }
 

--- a/src/main/kotlin/com/sunya/netchdf/hdf5/CdmBuilder.kt
+++ b/src/main/kotlin/com/sunya/netchdf/hdf5/CdmBuilder.kt
@@ -190,7 +190,7 @@ internal class DataContainerVariable(
 
     val isChunked : Boolean
     val elementSize : Int // total length in bytes on disk of one element
-    val useFillValue : Boolean
+    val onlyFillValue : Boolean // no data at all
     val fillValue : Any?
 
     init {
@@ -198,13 +198,13 @@ internal class DataContainerVariable(
         dataPos = when (mdl) {
             is DataLayoutContiguous -> h5.getFileOffset(mdl.dataAddress)
             is DataLayoutContiguous3 -> h5.getFileOffset(mdl.dataAddress)
-            is DataLayoutChunked -> h5.getFileOffset(mdl.btreeAddress)
+            is DataLayoutChunked -> mdl.btreeAddress // offset will be added in BTreeData
             else -> -1 // LOOK compact?
         }
 
         // deal with unallocated data
         fillValue = getFillValueNonDefault(h5, v5, h5type)
-        useFillValue = (dataPos == -1L)
+        onlyFillValue = (dataPos == -1L)
 
         isChunked = (mdl.layoutClass == LayoutClass.Chunked)
         when (mdl) {

--- a/src/main/kotlin/com/sunya/netchdf/hdf5/ChunkedData.kt
+++ b/src/main/kotlin/com/sunya/netchdf/hdf5/ChunkedData.kt
@@ -1,6 +1,5 @@
 package com.sunya.netchdf.hdf5
 
-import com.sunya.cdm.api.Section
 import com.sunya.cdm.layout.IndexSpace
 import com.sunya.cdm.layout.Odometer
 import com.sunya.cdm.layout.Tiling
@@ -48,7 +47,42 @@ class ChunkedData(val btree1 : BTree1New) {
         return node
     }
 
-    fun findDataChunkContainingKey(parent : BTree1New.Node, key : IntArray) : BTree1New.DataChunkEntry? {
+    // optimize later
+    fun findEntryContainingKey(parent : BTree1New.Node, key : IntArray) : BTree1New.DataChunkEntry? {
+        var foundEntry : BTree1New.DataChunkEntry? = null
+        for (idx in 0 until parent.nentries) {
+            foundEntry = parent.dataChunkEntries[idx]
+            if (idx < parent.nentries - 1) {
+                val nextEntry = parent.dataChunkEntries[idx + 1] // look at the next one
+                if (tiling.compare(key, nextEntry.key.offsets) < 0) {
+                    break
+                }
+            }
+        }
+        if (foundEntry == null) {
+            throw RuntimeException("wtf")
+        }
+        if (parent.level == 0) {
+            return if (tiling.compare(key, foundEntry.key.offsets) == 0) foundEntry else null
+        }
+        val node= readNode(foundEntry.childAddress, parent)
+        return findEntryContainingKey(node, key)
+    }
+
+    /*
+    fun findEntryContainingKey(lastEntry : BTree1New.DataChunkEntry, key : IntArray) : BTree1New.DataChunkEntry? {
+        if (tiling.compare(key, lastEntry.key.offsets) == 0) {
+            return lastEntry
+        }
+        if (tiling.compare(key, lastEntry.key.offsets) < 0) {
+            return null // missing
+        }
+        var useEntry : BTree1New.DataChunkEntry = lastEntry
+        while (tiling.compare(key, useEntry.key.offsets) > 0) {
+            useEntry = nextEntry(useEntry)?: return null
+       }
+
+        val parent = lastEntry?.parent ?: rootNode
         var foundEntry : BTree1New.DataChunkEntry? = null
         for (idx in 0 until parent.nentries) {
             foundEntry = parent.dataChunkEntries[idx]
@@ -64,21 +98,27 @@ class ChunkedData(val btree1 : BTree1New) {
         }
         if (parent.level == 0) {
             if (tiling.compare(key, foundEntry.key.offsets) != 0) {
-                println(" *** tile(s) missing")
-                return null
-                // throw RuntimeException("tile missing") // missing tile, ideally return fillvalue
+                println(" *** tile missing")
+                // (val level : Int, val parent : Node, val idx : Int, val key : DataChunkKey, val childAddress : Long)
+                // (val chunkSize: Int, val filterMask : Int, val offsets: IntArray)
+                // a "missing data chunk"
+                return BTree1New.DataChunkEntry(0, parent, -1, BTree1New.DataChunkKey(-1, 0, key), -1L)
+                // throw RuntimeException("tile missing") // missing tile, TODO return fillvalue
             }
             return foundEntry
         }
         val node= readNode(foundEntry.childAddress, parent)
-        return findDataChunkContainingKey(node, key)
-    }
+        return findEntryContainingKey(node, key)
+    } */
 
-    // find the next chunk in the btree
-    fun nextDataChunk(chunk : BTree1New.DataChunkEntry) : BTree1New.DataChunkEntry? {
-        val node = chunk.parent
-        if (chunk.idx < node.nentries - 1) {
-            return node.dataChunkEntries[chunk.idx + 1]
+    // find the next entry in the btree
+    fun nextEntry(entry : BTree1New.DataChunkEntry) : BTree1New.DataChunkEntry? {
+        if (entry.isMissing()) {
+            return null
+        }
+        val node = entry.parent
+        if (entry.idx < node.nentries - 1) {
+            return node.dataChunkEntries[entry.idx + 1]
         }
         if (node.rightAddress == -1L) {
             return null
@@ -87,55 +127,59 @@ class ChunkedData(val btree1 : BTree1New) {
         return nextSibling.dataChunkEntries[0]
     }
 
-    fun findDataChunks(wantSection : Section) : Iterable<BTree1New.DataChunkEntry> {
+    fun findDataChunks(wantSpace : IndexSpace) : Iterable<BTree1New.DataChunkEntry> {
         val chunks = mutableListOf<BTree1New.DataChunkEntry>()
 
-        val tileSection = tiling.section( IndexSpace(wantSection)) // section in tiles that we want
+        val tileSection = tiling.section( wantSpace) // section in tiles that we want
         val tileOdometer = Odometer(tileSection, tiling.tileShape) // loop over tiles we want
-        while (!tileOdometer.isDone()) {
-            val firstTile = tileOdometer.current
-            val firstKey = tiling.index(firstTile) // convert to index "keys"
-            val firstChunk = findDataChunkContainingKey(rootNode, firstKey)
-            if (firstChunk != null) {
-                if (check) require(wantSection.intersects(IndexSpace(firstChunk.key.offsets, tiling.chunk).makeSection()))
-                if (debugRow) print("tilesInRow = ${firstTile.contentToString()}")
-                val chunksAdded = addDataChunkRow(wantSection, firstChunk, chunks) // can efficiently find the chunks along the first dimension
-                if (debugRow) println()
-                tileOdometer.add(chunksAdded)
-            } else {
-                break
-                // the remaining chunks are missing, TODO use fillvalue. for now, skipping will give 0's
-            }
-        }
+        // println("tileSection = ${tileSection}")
 
+        // var lastEntry : BTree1New.DataChunkEntry? = null
+        while (!tileOdometer.isDone()) {
+            val wantTile = tileOdometer.current
+            val wantKey = tiling.index(wantTile) // convert to index "keys"
+            val haveEntry = findEntryContainingKey(rootNode, wantKey)
+            val useEntry = haveEntry?: BTree1New.DataChunkEntry(0, rootNode, -1, BTree1New.DataChunkKey(-1, 0, wantKey), -1L)
+            chunks.add(useEntry)
+            tileOdometer.incr()
+            // if (haveEntry != null) lastEntry = haveEntry
+        }
+        // println("nchunks = ${chunks.size}")
         return chunks
     }
 
-    // add all the chunks along this row until section no longer contains them
-    fun addDataChunkRow(wantSection : Section, starting : BTree1New.DataChunkEntry, chunks : MutableList<BTree1New.DataChunkEntry>) : Int {
+    /* add all the chunks along this row until section no longer contains them
+    fun addDataChunkRow(wantSpace : IndexSpace, starting : BTree1New.DataChunkEntry,
+                        chunks : MutableList<BTree1New.DataChunkEntry>,
+                        chunkMap : MutableMap<BTree1New.DataChunkKey, BTree1New.DataChunkEntry>,
+                        ) : Int {
         var count = 0
         var useChunk = starting
         while (true) {
+            val dup = chunkMap[useChunk.key]
+            if (dup != null) {
+                println("duplicate")
+            }
             chunks.add(useChunk)
+            chunkMap[useChunk.key] = useChunk
+
             count++
-            val nextChunk = nextDataChunk(useChunk)
+            val nextChunk = nextEntry(useChunk)
             if (nextChunk == null) {
                 break
             } else {
                 val nextIndexShape = IndexSpace(nextChunk.key.offsets, tiling.chunk)
-                val nextIndexSection = nextIndexShape.makeSection()
-                val needed = wantSection.intersects(nextIndexSection) // LOOK replace
+                val needed = wantSpace.intersects(nextIndexShape)
                 if (!needed) {
                     break
                 } else if (debugRow) {
                     print(", ${tiling.tile(nextChunk.key.offsets).contentToString()}")
                 }
-
             }
             useChunk = nextChunk
         }
         return count
-    }
+    } */
 
     override fun toString(): String {
         return "ChunkedData(chunk=${btree1.storageSize.contentToString()}, readHit=$readHit, readMiss=$readMiss)"

--- a/src/main/kotlin/com/sunya/netchdf/hdf5/H5TypeInfo.kt
+++ b/src/main/kotlin/com/sunya/netchdf/hdf5/H5TypeInfo.kt
@@ -16,6 +16,7 @@ internal class H5TypeInfo(mdt: DatatypeMessage) {
     val elemSize: Int = mdt.elemSize
     val endian: ByteOrder = mdt.endian()
     val isVString = if (mdt is DatatypeVlen) mdt.isVString else false // is a vlen string
+    val isRefObject = if (mdt is DatatypeReference) mdt.referenceType == 0 else false // is a vlen string
 
     var unsigned = false
     var base: H5TypeInfo? = null // used for vlen, array
@@ -74,7 +75,7 @@ internal class H5TypeInfo(mdt: DatatypeMessage) {
 
             Datatype5.Time -> Datatype.LONG.withSignedness(true) // LOOK use bitPrecision i suppose
             Datatype5.String -> Datatype.CHAR // fixed length strings. String is used for Vlen type = 1
-            Datatype5.Reference -> Datatype.STRING // LOOK could be something else; String's all weve seen, references are not supported
+            Datatype5.Reference -> Datatype.LONG // addresses; type 1 gets converted to object name
 
             Datatype5.Opaque -> {
                 val typedef = h5builder.findTypedef(this.mdtAddress, this.mdtHash)

--- a/src/main/kotlin/com/sunya/netchdf/hdf5/H5filters.kt
+++ b/src/main/kotlin/com/sunya/netchdf/hdf5/H5filters.kt
@@ -15,7 +15,7 @@ class H5filters(
     val mfp: FilterPipelineMessage?,
     val byteOrder: ByteOrder
 ) {
-    val inflateBufferSize = 20_000 // LOOK make this settable
+    val inflateBufferSize = 80_000 // LOOK make this settable
     var first = true
 
     fun apply(rawdata: ByteBuffer, entry: BTree1New.DataChunkEntry): ByteBuffer {
@@ -23,6 +23,7 @@ class H5filters(
         // if (first) println("  ** Filtered $varname ${mfp.filters.map { it.name}}")
         first = false
 
+        // LOOK can you hook the streams up rather than writing to bytearray at each step ??
         var data = rawdata.array()
         try {
             // apply filters backwards

--- a/src/main/kotlin/com/sunya/netchdf/hdf5/MessageDataLayout.kt
+++ b/src/main/kotlin/com/sunya/netchdf/hdf5/MessageDataLayout.kt
@@ -41,7 +41,7 @@ fun H5builder.readDataLayoutMessage(state : OpenFileState) : DataLayoutMessage {
                 if (layoutClass != 0) { // not compact
                     fld("dataAddress", sizeOffsets)
                 }
-                array("dims", sizeLengths, "rank")
+                array("dims", 4, "rank")
                 if (layoutClass == 2) { // chunked
                     fld("chunkedElementSize", 4)
                 }

--- a/src/main/kotlin/com/sunya/netchdf/hdf5/MessageHeader.kt
+++ b/src/main/kotlin/com/sunya/netchdf/hdf5/MessageHeader.kt
@@ -636,7 +636,7 @@ fun H5builder.readAttributeMessage(state: OpenFileState): AttributeMessage {
     val name = rawdata.getString("name") // this has terminating zero removed
     if (version == 1) {
         // use the full width to decide on padding
-        state.pos += padding(rawdata.getByte("nameLength").toInt(), 8)
+        state.pos += padding(rawdata.getShort("nameLength").toInt(), 8)
     }
 
     // read the datatype

--- a/src/main/kotlin/com/sunya/netchdf/netcdf3/Netcdf3File.kt
+++ b/src/main/kotlin/com/sunya/netchdf/netcdf3/Netcdf3File.kt
@@ -3,6 +3,7 @@ package com.sunya.netchdf.netcdf3
 import com.sunya.cdm.api.*
 import com.sunya.cdm.array.*
 import com.sunya.cdm.iosp.*
+import com.sunya.netchdf.netcdf4.NetchdfFileFormat
 import java.io.IOException
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
@@ -25,6 +26,7 @@ class Netcdf3File(val filename : String) : Iosp, Netcdf {
     override fun rootGroup() = rootGroup
     override fun location() = filename
     override fun cdl(strict : Boolean) = com.sunya.cdm.api.cdl(this, strict)
+    override fun type() = NetchdfFileFormat.NC_FORMAT_CLASSIC.formatName()
 
     @Throws(IOException::class)
     override fun readArrayData(v2: Variable, section: Section?): ArrayTyped<*> {
@@ -43,6 +45,7 @@ class Netcdf3File(val filename : String) : Iosp, Netcdf {
         val vinfo = v2.spObject as N3header.Vinfo
         val nbytes = (vinfo.elemSize * v2.nelems)
         require(nbytes < Int.MAX_VALUE)
+        require(nbytes < 100_000_000) { "${v2.name}[${wantSection}]"}
         val filePos = OpenFileState(vinfo.begin, ByteOrder.BIG_ENDIAN)
         val values = ByteBuffer.allocate(nbytes.toInt())
 

--- a/src/main/kotlin/com/sunya/netchdf/netcdfClib/NetcdfClibFile.kt
+++ b/src/main/kotlin/com/sunya/netchdf/netcdfClib/NetcdfClibFile.kt
@@ -1,16 +1,13 @@
 package com.sunya.netchdf.netcdfClib
 
 import com.sunya.cdm.api.*
-import com.sunya.cdm.api.Section.Companion.computeSize
 import com.sunya.cdm.array.*
 import com.sunya.cdm.iosp.*
 import com.sunya.netchdf.netcdfClib.ffm.nc_vlen_t
 import com.sunya.netchdf.netcdfClib.ffm.netcdf_h.*
-import java.io.IOException
 import java.lang.foreign.*
 import java.lang.foreign.ValueLayout.*
 import java.nio.*
-import java.util.*
 
 /*
 apt-cache search netcdf
@@ -40,6 +37,7 @@ class NetcdfClibFile(val filename: String) : Iosp, Netcdf {
     override fun rootGroup() = rootGroup
     override fun location() = filename
     override fun cdl(strict: Boolean) = com.sunya.cdm.api.cdl(this, strict)
+    override fun type() = "read from C library"
 
     override fun close() {
         // NOOP

--- a/src/test/kotlin/com/sunya/cdm/iosp/TestChunker.kt
+++ b/src/test/kotlin/com/sunya/cdm/iosp/TestChunker.kt
@@ -17,7 +17,7 @@ class TestChunker {
                        expect : (Int) -> Pair<Int, Int>) {
         println("Chunker dataChunk = ${dataChunk.makeSection()} wantSection = [$wantSection]")
 
-        val layout = Chunker(dataChunk, 4, wantSection, merge)
+        val layout = Chunker(dataChunk, 4, IndexSpace(wantSection), merge)
         val expectNelems = expectElems ?: (dataChunk.totalElements.toInt() / expectNchunks)
         var count = 0
         var totalNelems = 0

--- a/src/test/kotlin/com/sunya/netchdf/NetchdfExtra.kt
+++ b/src/test/kotlin/com/sunya/netchdf/NetchdfExtra.kt
@@ -1,0 +1,92 @@
+package com.sunya.netchdf
+
+import com.sunya.cdm.api.*
+import com.sunya.cdm.api.Section.Companion.computeSize
+import com.sunya.cdm.iosp.Iosp
+import com.sunya.netchdf.netcdf4.openNetchdfFile
+import com.sunya.netchdf.netcdfClib.NetcdfClibFile
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import test.util.testFilesIn
+import java.util.*
+import java.util.stream.Stream
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+// Compare header using cdl(!strict) with Netchdf and NetcdfClibFile
+class NetchdfExtra {
+
+    companion object {
+        @JvmStatic
+        fun params(): Stream<Arguments> {
+            val stream =
+                testFilesIn("/media/twobee/netch")
+                    .withRecursion()
+                    .withPathFilter { p -> !p.toString().contains("hdf4") }
+                    .addNameFilter { name -> !name.endsWith(".cdl") }
+                    .addNameFilter { name -> !name.endsWith(".jpg") }
+                    .addNameFilter { name -> !name.endsWith(".gif") }
+                    .addNameFilter { name -> !name.endsWith(".ncml") }
+                    .addNameFilter { name -> !name.endsWith(".png") }
+                    .addNameFilter { name -> !name.endsWith(".pdf") }
+                    .addNameFilter { name -> !name.endsWith(".tif") }
+                    .addNameFilter { name -> !name.endsWith(".tiff") }
+                    .addNameFilter { name -> !name.endsWith(".txt") }
+                    .addNameFilter { name -> !name.endsWith(".xml") }
+                    .build()
+
+            // return moar3
+            return Stream.of(stream).flatMap { i -> i };
+        }
+
+        const val topdir = "/media/twobee/netch/"
+    }
+
+    // npp filers: superblock at file offset; reference data type
+     //*** not a netchdf file = /media/twobee/netch/webb/GATRO-SATMR_npp_d20020906_t0409572_e0410270_b19646_c20090720223122943227_devl_int.h5
+     //*** not a netchdf file = /media/twobee/netch/jasmine/VCBHO_npp_d20030125_t084955_e085121_b00015_c20071213022754_den_OPS_SEG.h5
+     //*** not a netchdf file = /media/twobee/netch/jasmine/VCBHO_npp_d20030125_t084830_e084955_b00015_c20071213022754_den_OPS_SEG.h5
+     //*** not a netchdf file = /media/twobee/netch/jasmine/SVM03_npp_d20111213_t1233213_e1234454_b00654_c20111213204856240464_noaa_ops.h5
+     //*** not a netchdf file = /media/twobee/netch/jasmine/GCLDO_npp_d20030125_t084955_e085121_b00015_c20071213022754_den_OPS_SEG.h5
+     //*** not a netchdf file = /media/twobee/netch/jasmine/GCLDO_npp_d20030125_t084830_e084955_b00015_c20071213022754_den_OPS_SEG.h5
+     //*** not a netchdf file = /media/twobee/netch/jasmine/GMTCO_npp_d20111213_t1233213_e1234454_b00654_c20111213204123306064_noaa_ops.h5
+    @Test
+    fun h5npp() {
+        NetchdfTest.showData = false
+        readData(topdir + "jasmine/VCBHO_npp_d20030125_t084955_e085121_b00015_c20071213022754_den_OPS_SEG.h5")
+//)
+        readData(topdir + "webb/GATRO-SATMR_npp_d20020906_t0409572_e0410270_b19646_c20090720223122943227_devl_int.h5")
+            // , "/Data_Products/ATMS-REMAP-SDR/ATMS-REMAP-SDR_Aggr")
+    }
+
+    val showCdl= false
+
+    @ParameterizedTest
+    @MethodSource("params")
+    fun compareCdlWithClib(filename: String) {
+        val netchdf: Netcdf? = openNetchdfFile(filename)
+        if (netchdf == null) {
+            println("*** not a netchdf file = $filename")
+            return
+        }
+        println("filename $filename type ${netchdf.type()}")
+        if (showCdl) println("\nnetchdf = ${netchdf.cdl()}")
+        val nclibfile: Netcdf = NetcdfClibFile(filename)
+        assertEquals(nclibfile.cdl(), netchdf.cdl())
+
+        netchdf.close()
+        nclibfile.close()
+    }
+
+    @ParameterizedTest
+    @MethodSource("params")
+    fun readDataForProfiling(filename: String) {
+        println(filename)
+        readData(filename)
+        println()
+    }
+}

--- a/src/test/kotlin/com/sunya/netchdf/hdf5/H5dataCompare.kt
+++ b/src/test/kotlin/com/sunya/netchdf/hdf5/H5dataCompare.kt
@@ -38,14 +38,14 @@ class H5dataCompare {
                     .build()
 
             val moar4 =
-                testFilesIn(oldTestDir + "formats/netcdf4")
+                testFilesIn(oldTestDir + "formats/netcdf4/new")
                     .withRecursion()
                     .withPathFilter { p -> !p.toString().contains("exclude") }
                     .addNameFilter { name -> !name.endsWith("perverse.nc") } // too slow
                     .build()
 
-            // return stream1
-            return Stream.of(stream1, stream4, moar4).flatMap { i -> i};
+            return moar4
+            // return Stream.of(stream1, stream4, moar4).flatMap { i -> i};
         }
     }
 
@@ -69,6 +69,11 @@ class H5dataCompare {
         readDataCompareNC("/media/snake/0B681ADF0B681ADF1/thredds-test-data/local/thredds-test-data/cdmUnitTest/formats/netcdf4/files/c0.nc")
     }
 
+    @Test
+    fun problem2() {
+        readDataCompareNC("/media/snake/0B681ADF0B681ADF1/thredds-test-data/local/thredds-test-data/cdmUnitTest/formats/netcdf4/new/OR_ABI-L2-CMIPF-M6C13_G16_s20230451800207_e20230451809526_c20230451810015.nc", "CMI")
+    }
+
     @ParameterizedTest
     @MethodSource("params")
     fun readH5dataCompareNC(filename: String) {
@@ -89,8 +94,8 @@ class H5dataCompare {
     }
 }
 
-var debugCompareNetcdf = true
 var showData = false
+var showFailedData = false
 
 fun compareNetcdf(myfile: Netcdf, ncfile: Netcdf, varname: String?, section: Section? = null) {
     if (varname != null) {
@@ -133,10 +138,14 @@ fun oneVar(myvar: Variable, h5file: Iosp, ncvar : Variable, ncfile: Iosp, sectio
         } else {
             if (!ArrayTyped.contentEquals(ncdata, mydata)) {
                 println(" *** FAIL comparing data for variable = ${ncvar.datatype} ${ncvar.name} ${ncvar.dimensions.map { it.name }}")
-                println("\n mydata = $mydata")
-                println(" ncdata = $ncdata")
-                ArrayTyped.contentEquals(ncdata, mydata)
-                assertTrue(false)
+                if (showFailedData) {
+                    println("\n mydata = $mydata")
+                    println(" ncdata = $ncdata")
+                    ArrayTyped.contentEquals(ncdata, mydata)
+                    assertTrue(false)
+                } else {
+                    println("\n countDifferences = ${ArrayTyped.countDiff(ncdata, mydata)}")
+                }
                 return
             } else {
                 if (showData) {
@@ -176,8 +185,12 @@ fun testMiddleSection(myfile: Iosp, myvar: Variable, ncfile: Iosp, ncvar: Variab
     } else {
         if (!ArrayTyped.contentEquals(ncdata, mydata)) {
             println(" *** FAIL comparing middle section variable = ${ncvar}")
-            println(" mydata = $mydata")
-            println(" ncdata = $ncdata")
+            if (showFailedData) {
+                println(" mydata = $mydata")
+                println(" ncdata = $ncdata")
+            } else {
+            println("\n countDifferences = ${ArrayTyped.countDiff(ncdata, mydata)}")
+        }
             assertTrue(false)
             return
         }

--- a/src/test/kotlin/com/sunya/netchdf/hdf5/H5dataTiming.kt
+++ b/src/test/kotlin/com/sunya/netchdf/hdf5/H5dataTiming.kt
@@ -73,6 +73,13 @@ class H5dataTiming {
         readData(chunked2, "UpperDeschutes_t4p10_swemelt", Section("0:100, 0:30, 0:40"))
     }
 
+    @Test
+    fun hasMissing() {
+        val filename = "/media/snake/0B681ADF0B681ADF1/thredds-test-data/local/thredds-test-data/cdmUnitTest/formats/netcdf4/new/OR_ABI-L2-CMIPF-M6C13_G16_s20230451800207_e20230451809526_c20230451810015.nc"
+        readData(filename, "CMI", Section(":, :"))
+        readData(filename, "DQF", Section(":, :"))
+    }
+
     val showDetail = true
 
     fun readData(filename: String, varname: String, readSection : Section) {

--- a/src/test/kotlin/com/sunya/netchdf/hdf5/H5headerCompare.kt
+++ b/src/test/kotlin/com/sunya/netchdf/hdf5/H5headerCompare.kt
@@ -30,7 +30,7 @@ class H5headerCompare {
             )
 
             val stream4 =
-                testFilesIn("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4")
+                testFilesIn("/media/snake/0B681ADF0B681ADF1/thredds-test-data/local/thredds-test-data/cdmUnitTest/formats/netcdf4/")
                     .addNameFilter { name -> !name.endsWith("tst_grps.nc4") } // nested group typedefs
                     .withRecursion()
                     .build()
@@ -42,14 +42,14 @@ class H5headerCompare {
                     .withRecursion()
                     .build()
 
-            return Stream.of(stream4).flatMap { i -> i };
-            //return stream2
+            //. return Stream.of(stream4).flatMap { i -> i };
+            return stream4
         }
     }
 
     // @Test failing because differs from ncfile
     fun problem() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_grps.nc4")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_grps.nc4")
     }
     /*
     ncfile adds extra typedefs:
@@ -104,7 +104,7 @@ class H5headerCompare {
 
     @Test
     fun tst_compounds() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_compounds.nc4")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_compounds.nc4")
     }
     /*
 netcdf tst_compounds {
@@ -126,23 +126,23 @@ variables:
 
     @Test
     fun sharedObject() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/test_enum_type.nc")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/test_enum_type.nc")
     }
 
     @Test
     fun fractalHeap() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/test_atomic_types.nc")
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/testCFGridWriter.nc4")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/test_atomic_types.nc")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/testCFGridWriter.nc4")
     }
 
     @Test
     fun hasTimeDataType() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/fpcs_1dwave_2.nc")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/fpcs_1dwave_2.nc")
     }
 
     @Test
     fun opaqueAttribute() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_opaque_data.nc4")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_opaque_data.nc4")
     }
 /*
 netcdf tst_opaque_data {
@@ -158,7 +158,7 @@ variables:
 
     @Test
     fun attEnum() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_enums.nc")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_enums.nc")
     }
     /*
 netcdf test_enum_type {
@@ -176,7 +176,7 @@ variables:
 
     @Test
     fun attVlen() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_vlen_data.nc4")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_vlen_data.nc4")
         // openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_solar_2.nc4")
     }
     /*
@@ -201,7 +201,7 @@ types:
 
     @Test
     fun varVlen() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/vlenInt.nc")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/vlenInt.nc")
     }
     /*
 netcdf vlenInt {
@@ -214,7 +214,7 @@ variables:
 
     @Test
     fun outofOrder() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/fpcs_1dwave_2.nc")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/fpcs_1dwave_2.nc")
     }
     /*
     snake@jlc:~$ ncdump -h /home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/fpcs_1dwave_2.nc
@@ -253,7 +253,7 @@ variables:
 
     @Test
     fun attArrayStruct() {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_solar_cmp.nc")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/tst_solar_cmp.nc")
     }
     /*
 netcdf tst_solar_cmp {
@@ -270,7 +270,7 @@ types:
 
     @Test // currently fails
     fun charVar () {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/dstr.h5")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/dstr.h5")
     }
 /*    netcdf dstr {
         variables:
@@ -280,7 +280,7 @@ types:
 
     @Test
     fun compoundInnerVlen () {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/IntTimSciSamp.nc")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/IntTimSciSamp.nc")
     }
 /*
 netcdf IntTimSciSamp {
@@ -351,7 +351,7 @@ data:
 
     @Test
     fun attCompoundInnerString () {
-        openH5("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/attributeStruct.nc")
+        compareH5andNclib("/home/snake/dev/github/netcdf/devcdm/core/src/test/data/netcdf4/attributeStruct.nc")
 }
     /*
     netcdf attributeStruct {
@@ -395,9 +395,14 @@ variables:
 
      */
 
+    @Test
+    fun problem2() {
+        compareH5andNclib("/media/snake/0B681ADF0B681ADF1/thredds-test-data/local/thredds-test-data/cdmUnitTest/formats/netcdf4/new/OR_ABI-L2-CMIPF-M6C13_G16_s20230451800207_e20230451809526_c20230451810015.nc")
+    }
+
     @ParameterizedTest
     @MethodSource("params")
-    fun openH5(filename: String) {
+    fun compareH5andNclib(filename: String) {
         println("=================")
         println(filename)
         val h5file = Hdf5File(filename, true)


### PR DESCRIPTION
deal correctly with missing data chunks
get npp hdf5 working (!); fix problems with offset superblocks 
Chunker, ChunkedData uses IndexSpace; add insersects(); simplify ChunkedData.findDataChunks()
improve StructDsl
Reference type has Long datatype, data is converted to Strings 
increase inflate buffer to 80K. Inflate when used generally dominates the time, is 2x slower than C library, I suspect.