### PR TITLE
Hdf4: Put eos metadata in its own group.

### DIFF
--- a/clibs/src/test/kotlin/com/sunya/netchdf/hdf4/HCcompare.kt
+++ b/clibs/src/test/kotlin/com/sunya/netchdf/hdf4/HCcompare.kt
@@ -90,10 +90,15 @@ class HCcompare {
 
 
     @Test
-    fun problem2() {
-        compareH4header(testData + "hdf4/nsidc/LAADS/MYD/MYD01.A2007001.0440.005.2007311085701.hdf")
-        compareData(testData + "hdf4/nsidc/LAADS/MYD/MYD01.A2007001.0440.005.2007311085701.hdf")
+    fun problem() {
+        compareH4header(testData + "hdf4/eos/modis/MOD35_L2.A2000243.1850.003.hdf")
     }
+
+    @Test
+    fun problem2() {
+        readHCheader(testData + "hdf4/nsidc/LP_DAAC/MYD/MYD09A1.A2007273.h03v07.005.2007285103507.hdf")
+    }
+
 
     //////////////////////////////////////////////////////////////////////
 

--- a/core/src/main/kotlin/com/sunya/cdm/api/Group.kt
+++ b/core/src/main/kotlin/com/sunya/cdm/api/Group.kt
@@ -144,6 +144,14 @@ class Group(orgName : String,
             return this
         }
 
+        fun addAttributeIfNotExists(att: Attribute) : Boolean {
+            if (attributes.find {it.name == att.name } != null) {
+                return false
+            }
+            attributes.add(att)
+            return true
+        }
+
         // add if vb name not already added
         fun addVariable(vb: Variable.Builder) : Builder {
             if (variables.find {it.name == vb.name } == null) {

--- a/core/src/main/kotlin/com/sunya/netchdf/hdf4/ODLparser.kt
+++ b/core/src/main/kotlin/com/sunya/netchdf/hdf4/ODLparser.kt
@@ -29,7 +29,8 @@ import java.util.*
  * information be included in an HDF-EOS file? Yes. The descriptor file will be retained. It can be viewed by
  * EOSView if it stored either as a global attribute or a file annotation.
  */
-private val EOSprefix = listOf("archivemetadata",  "coremetadata", "productmetadata", "structmetadata", "oldstructmetadata")
+private val EOSprefix = listOf("archivemetadata",  "coremetadata", "productmetadata", "structmetadata", "oldstructmetadata",
+    "gridstructure", "pointstructure", "swathstructure")
 
 class EOS {
     companion object {

--- a/core/src/main/kotlin/com/sunya/netchdf/hdf4/Tag.kt
+++ b/core/src/main/kotlin/com/sunya/netchdf/hdf4/Tag.kt
@@ -52,8 +52,8 @@ fun readTag(raf : OpenFile, state: OpenFileState): Tag {
 open class Tag(xtag: Int, val refno : Int, val offset : Long, val length : Int) {
     val isExtended: Boolean = (xtag and 0x4000) != 0
     val code = (xtag and 0x3FFF) // basic tag
-    // var t: TagEnum = TagEnum.byCode(this.code)
-    var isUsed = false
+
+    internal var isUsed = false
     internal var vinfo: Vinfo? = null
 
     // read the offset/length part of the tag. overridden by subclasses

--- a/testdata/src/main/kotlin/com/sunya/testdata/H4Files.kt
+++ b/testdata/src/main/kotlin/com/sunya/testdata/H4Files.kt
@@ -23,7 +23,7 @@ class H4Files {
                 testFilesIn(testData + "hdf4")
                     .withRecursion()
                     //    .withPathFilter { p -> !(p.toString().contains("/eos/"))}
-                    .addNameFilter { name -> !name.endsWith("VHRR-KALPANA_20081216_070002.hdf") }
+                    // .addNameFilter { name -> !name.endsWith("VHRR-KALPANA_20081216_070002.hdf") }
                     .build()
 
             return Stream.of(devcdm, hdfeos2, hdf4NoCore).flatMap { i -> i }


### PR DESCRIPTION
H4C: look for more global attributes with SDreadAttribute(). 
H4: rewrite VgroupVarSD() to eliminate order of massages.
       Get rid of completedObjects, use tag.isUsed.
Add more EOS prefixes.